### PR TITLE
Warn instead of abort if arm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ endif ()
 
 
 if (NOT DEFINED SKBUILD)
-    message(WARNING "Not building with scikit-build")
+    message(STATUS "Not building with scikit-build; using a local virtual environment instead")
     include(cmake/python-venv.cmake)
 endif ()
 set(Python3_USE_STATIC_LIBS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ target_link_libraries(
         ${Boost_LIBRARIES}
 )
 if (${IS_AARCH64})
-    message(FATAL_ERROR "ARM based architectures are not yet supported")
+    message(WARNING "ARM based architectures are not yet supported")
 else ()
     if (APPLE)
         target_link_libraries(gaussianfft_gaussianfft PRIVATE

--- a/cmake/mkl-fftw.cmake
+++ b/cmake/mkl-fftw.cmake
@@ -1,9 +1,9 @@
 # Configure Intel MKL & FFTW (for Apple M-series)
 if (${IS_AARCH64})
     if (APPLE)
-        message(FATAL_ERROR "Apple Silicon is not yet supported")
+        message(WARNING "Apple Silicon is not yet supported")
     else ()
-        message(FATAL_ERROR "ARM based systems is not yet supported")
+        message(WARNING "ARM based systems is not yet supported")
     endif ()
 else ()
     # MKL


### PR DESCRIPTION
Should make it possible to use IDEs relying on `cmake` on ARM based machines (e.g. Apple Silicon based Macs) even if it is not currently possible to build for them.