### PR TITLE
Require `scikit-build-core` 0.8.0 or greater

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ util = ["scipy"]
 [build-system]
 requires = [
     # Scikit-build-core does not support Python 3.6 (and older)
-    "scikit-build-core ; python_version >= '3.7'",
+    "scikit-build-core >= 0.8 ; python_version >= '3.7'",
 
     "mkl-static ; platform_machine == 'x86_64' or platform_machine == 'AMD64'",
     "mkl-devel ; platform_machine == 'x86_64' or platform_machine == 'AMD64'",
@@ -68,7 +68,7 @@ requires = [
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
-cmake.minimum-version = "3.19"
+cmake.version = ">=3.19"
 
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 


### PR DESCRIPTION
`0.8.0` deprecated `minimum-version` in favour of using `version` with a regular modifier