### PR TITLE
No longer necessary to try to import `roxar`

### DIFF
--- a/gaussianfft/__init__.py
+++ b/gaussianfft/__init__.py
@@ -4,13 +4,6 @@ from importlib.util import find_spec
 if find_spec("numpy") is None:
     raise ImportError("gaussianfft requires NumPy to be installed")
 
-try:
-    # When using gaussianFFT in conjunction with Aspen RMS (former Emerson / Roxar)
-    # you could experience a segmentation fault if gaussianfft was imported before
-    # the roxar module.
-    import roxar
-except ImportError:
-    pass
 
 import _gaussianfft
 


### PR DESCRIPTION
The reason for this, is that we use the same version of `numpy` as RMS uses for the different versions of Python / RMS