### PR TITLE
[refactor] Build packages with `cibuildwheels`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,7 @@ jobs:
           # a different fftw3 implementation must be used
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_SKIP: "*-musllinux_x86_64"
+          CIBW_ENABLE: "pypy"
         with:
           output-dir: 'dist'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
         id: cache-armpl
         uses: actions/cache@v3
         with:
+          lookup-only: true
           path: sources/arm-performance-libraries/${{ matrix.armpl }}/${{ runner.os }}
           key: armpl-${{ matrix.armpl }}-${{ matrix.os }}-${{ hashFiles('bin/fetch-ArmPL.sh') }}
 
@@ -29,6 +30,7 @@ jobs:
           ./bin/fetch-ArmPL.sh ${{ matrix.armpl }}
 
       - name: Store headers and libraries
+        if: steps.cache-armpl.outputs.cache-hit != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: armpl-${{ matrix.armpl }}-${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,27 +42,12 @@ jobs:
     name: Build & Test
     strategy:
       matrix:
-        python:
-        - 3.7
-        - 3.8  # Included in RMS 12.1, and newer
-        - 3.9
-        - "3.10"
-        - 3.11  # Included in RMS 14.2, and newer
-        - 3.12
         os:
         - ubuntu-20.04
         # Intel based
         - macos-11
         # ARM based
         - macos-14
-        exclude:
-          # Python 3.7-3.9 are not available on ARM64
-          - os: macos-14
-            python: 3.7
-          - os: macos-14
-            python: 3.8
-          - os: macos-14
-            python: 3.9
 
     steps:
       - uses: actions/checkout@v4
@@ -79,42 +64,21 @@ jobs:
           path: sources/arm-performance-libraries
           merge-multiple: true
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python }}
-
-      - name: Build
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22.0
         env:
-          PYTHON: python${{ matrix.python }}
-          VERBOSE: "1"
-        run: |
-          if [[ $RUNNER_OS == "Linux" ]]; then
-            # Ensure shared directories have the correct permissions
-            mkdir -p dist wheelhouse
-            docker-compose run build-linux
-          elif [[ $RUNNER_OS == "macOS" ]]; then
-              make build
-          else
-            # That is, windows
-            echo "No supported, yet" >/dev/stderr
-            exit 1
-          fi
-        shell: bash
-
-      - name: Test
-        run: make tests
-
-      - name: Move results from auditwheel
-        # The reason for this, is because setuptools_scm and auditwheel
-        # causes an incompatibility between the updated wheels, which causes the installation during tests to fail
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          mv wheelhouse/*.whl dist/
+          # Intel MKL only support glibc x86 64bit Intel CPUs
+          # If you need to compile gaussianfft for other architectures,
+          # a different fftw3 implementation must be used
+          CIBW_ARCHS_LINUX: "x86_64"
+          CIBW_SKIP: "*-musllinux_x86_64"
+        with:
+          output-dir: 'dist'
 
       - name: Store wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.python }}-${{ matrix.os }}
+          name: wheels-${{ matrix.os }}
           path: dist/*.whl
           if-no-files-found: error
 
@@ -160,7 +124,7 @@ jobs:
       - name: Download compiled wheels
         uses: actions/download-artifact@v4
         with:
-          pattern: wheel-*
+          pattern: wheels-*
           path: .
           merge-multiple: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
         os:
         - ubuntu-20.04
         # Intel based
-        - macos-11
+        - macos-13
         # ARM based
         - macos-14
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ set_target_properties(
         VISIBILITY_INLINES_HIDDEN YES
         EXPORT_NAME _gaussianfft
         OUTPUT_NAME _gaussianfft
+        SUFFIX ".${SKBUILD_SOABI}${CMAKE_SHARED_LIBRARY_SUFFIX}"
 )
 
 target_link_libraries(

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -19,6 +19,7 @@ function(dependants output_variables)
     set(ENV{CXXFLAGS} ${CMAKE_CXX_FLAGS})
     get_property(include_directories DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
     list(APPEND include_directories ${CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES} ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
+    list(APPEND include_directories ${Python3_INCLUDE_DIRS} ${pybind11_INCLUDE_DIR})
 #    message(FATAL_ERROR ${include_directories})
 #    list(APPEND include_directories "/Users/SNIS/Projects/APS/gaussianfft/sources/arm-performance-libraries/armpl_23.10_flang-new_clang_17/include_int64_mp")
     execute_process(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,9 @@ build-backend = "scikit_build_core.build"
 [tool.cibuildwheel]
 test-requires = [
     "pytest",
-    "scipy",
+    # There are no pre-compiled wheels available for pypy, so we use a (custom)
+    # pure Python implementation of the functions we use from SciPy
+    "scipy;platform_python_implementation!='PyPy'",
 ]
 test-command = "pytest {project}/tests"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Mathematics",
@@ -34,7 +35,7 @@ classifiers = [
 dependencies = [
     "numpy",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 
 [project.urls]
 Homepage = "https://equinor.com"
@@ -56,6 +57,13 @@ requires = [
     "pybind11[global]",
 ]
 build-backend = "scikit_build_core.build"
+
+[tool.cibuildwheel]
+test-requires = [
+    "pytest",
+    "scipy",
+]
+test-command = "pytest {project}/tests"
 
 [tool.scikit-build]
 cmake.version = ">=3.19"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,36 @@
+import numpy as np
+import numpy.typing as npt
+import math
+from typing import Union
+
+
+# This is a pure Python implementation of the chi2 probability distribution
+# which we use in one of the tests.
+# The main reason for this is that pypy requires scipy to be compiled from source
+# which is quite cumbersome and time-consuming to do in the CI.
+
+
+class chi2:
+    @staticmethod
+    def pdf(x: Union[npt.NDArray, float], df: int) -> npt.NDArray:
+        """Probability density function at x of the given RV.
+
+        :param x: quantiles
+        :param df: degrees of freedom
+        :returns: Probability density function evaluated at x"""
+        return 1 / (2 ** (df / 2) * math.gamma(df / 2) ) * x ** (df / 2 - 1) * np.exp(-x / 2)
+
+    @classmethod
+    def ppf(cls, q: float, df: int):
+        """Percent point function (inverse of cdf) at q of the given RV.
+
+        :param q: lower tail probability
+        :param df: degrees of freedom
+        :returns: quantile corresponding to the lower tail probability q."""
+        prob_range = 1500  # The pdf at this point is 0.0
+        prob_resolution = 0.001
+        _x = np.linspace(0, prob_range, int(1 / prob_resolution) * prob_range + 1)
+        probabilities = cls.pdf(_x, df)
+        cdf = probabilities.cumsum()
+        cdf /= max(cdf)
+        return _x[cdf <= q][-1]

--- a/tests/test_simulate1d.py
+++ b/tests/test_simulate1d.py
@@ -44,7 +44,11 @@ def test_rolled_gradient(simulated_field):
 def test_chi2():
     # A multivariate normal vector, x, with covariance matrix S, shall satisfy x'(S^-1)x ~ chi2(x.size)
     # This test makes an approximate check of this assumption. Parameters are taken from a Hufsa case.
-    from scipy.stats import chi2
+    try:
+        from scipy.stats import chi2
+    except ImportError:
+        from helpers import chi2
+
     nx = 40
     Lx = 8222
     rx = 6106


### PR DESCRIPTION
Replace the custom GitHub Actions steps for building the wheels with [`cibuildwheels`](https://cibuildwheel.pypa.io/en/stable/), which will build the wheel for all supported versions of Python.

This was originally part of #36, but I created a separate PR to make it easier to see the relevant changes that where necessary for Windows support.

There are some minor changes in this PR to accommodate [PyPY](https://pypy.org) which we did not support before.
Since `cibuildwheel` support it out of the box and it seems to work fine, we might as well start to publish wheels for it.