### PR TITLE
Simplify dependency management for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Some of the tests use functionality from [`scipy`](https://scipy.org).
 To run the tests, execute
 ```bash
 # Assuming you have activated a virtual environment
-pip install pytest scipy
+pip install --group 'test'
 pip install -e .  # To make sure `_gaussianfft` is compiled.
 
 pytest tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,13 +57,16 @@ requires = [
 ]
 build-backend = "scikit_build_core.build"
 
-[tool.cibuildwheel]
-test-requires = [
+[dependency-groups]
+test = [
     "pytest",
     # There are no pre-compiled wheels available for pypy, so we use a (custom)
     # pure Python implementation of the functions we use from SciPy
-    "scipy;platform_python_implementation!='PyPy'",
+    "scipy ; platform_python_implementation != 'PyPy'",
 ]
+
+[tool.cibuildwheel]
+test-groups = ["test"]
 test-command = "pytest {project}/tests"
 [tool.cibuildwheel.windows]
 # We use delvewheel to ensure _gaussianfft.lib, which is part of the build artefacts,


### PR DESCRIPTION
Defines the dependencies for running the tests under `[dependency-groups]` rather than in `tool.cibuildwheel.test-requires`.
That way, it is easier to reuse them, and makes `pyproject.toml` a little more standardised.