### PR TITLE
Trigger CI runs on both `push` and on PR activity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,17 @@
 name: Build, Test, and deploy
 
-on: [push]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+
 
 permissions:
   contents: read


### PR DESCRIPTION
Usually, a change to a PR is done via a `git push`, but that is not the case for external Pull Requests